### PR TITLE
[meego-rpm-config] Don't rely on %buildsubdir. JB#54855 OMP#SDK-592

### DIFF
--- a/macros
+++ b/macros
@@ -228,7 +228,7 @@ FFLAGS="${FFLAGS:-%optflags -I%_fmoddir}" ; export FFLAGS ; \
 LD_AS_NEEDED=1; export LD_AS_NEEDED ; \
 %{nil}
 
-%install %{?_enable_debug_packages:%{?buildsubdir:%{debug_package}}}\
+%install %{?_enable_debug_packages:%{debug_package}}\
 %%install\
 LANG=C\
 export LANG\


### PR DESCRIPTION
Relying on buildsubdir is unnecessary for building debuginfo/debugsource packages. After commit [a0699a1f9b9502c75d812b4fee52dec100ad5be7](https://github.com/rpm-software-management/rpm/commit/a0699a1f9b9502c75d812b4fee52dec100ad5be7) in rpm this macro started to be undefined for packages that use --build-in-place option, thus preventing debug packages from being built.