### PR TITLE
Fix stripping of binaries for changed file output

### DIFF
--- a/brp-strip
+++ b/brp-strip
@@ -9,6 +9,6 @@ fi
 for f in `find $RPM_BUILD_ROOT -type f \( -perm -0100 -o -perm -0010 -o -perm -0001 \) -exec file {} \; | \
         grep -v "^${RPM_BUILD_ROOT}/\?usr/lib/debug"  | \
 	grep -v ' shared object,' | \
-	sed -n -e 's/^\(.*\):[ 	]*ELF.*, not stripped/\1/p'`; do
+	sed -n -e 's/^\(.*\):[ 	]*ELF.*, not stripped.*/\1/p'`; do
 	$STRIP -g "$f" || :
 done

--- a/brp-strip-comment-note
+++ b/brp-strip-comment-note
@@ -13,7 +13,7 @@ fi
 # for already stripped elf files in the build root
 for f in `find $RPM_BUILD_ROOT -type f \( -perm -0100 -o -perm -0010 -o -perm -0001 \) -exec file {} \; | \
         grep -v "^${RPM_BUILD_ROOT}/\?usr/lib/debug"  | \
-	sed -n -e 's/^\(.*\):[ 	]*ELF.*, stripped/\1/p'`; do
+	sed -n -e 's/^\(.*\):[ 	]*ELF.*, stripped.*/\1/p'`; do
 	note="-R .note"
 	if $OBJDUMP -h $f | grep '^[ 	]*[0-9]*[ 	]*.note[ 	]' -A 1 | \
 		grep ALLOC >/dev/null; then

--- a/brp-strip-shared
+++ b/brp-strip-shared
@@ -15,6 +15,6 @@ fi
 for f in `find $RPM_BUILD_ROOT -type f -a -exec file {} \; | \
         grep -v "^${RPM_BUILD_ROOT}/\?usr/lib/debug"  | \
 	grep ' shared object,' | \
-	sed -n -e 's/^\(.*\):[ 	]*ELF.*, not stripped/\1/p'`; do
+	sed -n -e 's/^\(.*\):[ 	]*ELF.*, not stripped.*/\1/p'`; do
 	$STRIP --strip-unneeded "$f"
 done


### PR DESCRIPTION
When compiling Whisperfish (which is a Rust program, but IIUC gets the same symbol stripping as C++ programs), the symbols don't get stripped from the binary, because there are more than 256 symbols.

Cherry-pick from https://github.com/rpm-software-management/rpm/commit/5b4805df2085b0e7c4f09caad62638c3238b3bc1

Related forum thread: https://forum.sailfishos.org/t/cant-strip-more-than-256-symbols/12522