### PR TITLE
Various cleanups

### DIFF
--- a/macros
+++ b/macros
@@ -77,16 +77,7 @@
 	mandir=%{?buildroot:%{buildroot}}%{_mandir} \\\
 	infodir=%{?buildroot:%{buildroot}}%{_infodir} \\\
   install
-
-%make_install \
-  %{__make} \\\
-	DESTDIR=%{?buildroot:%{buildroot}} \\\
-	INSTALL_ROOT=%{?buildroot:%{buildroot}} \\\
-  install \
-  rm -f %{?buildroot:%{buildroot}}%{_infodir}/dir \
-  find %{?buildroot:%{buildroot}} -regex ".*\\.la$" | xargs rm -f -- \
-  %{!?keepstatic:find %{?buildroot:%{buildroot}} -regex ".*\\.a$" | xargs rm -f --}  
-
+  
 %_smp_mflags %([ -z "$RPM_BUILD_NCPUS" ] \\\
 	&& RPM_BUILD_NCPUS="`/usr/bin/getconf _NPROCESSORS_ONLN`"; \\\
 	[ "$RPM_BUILD_NCPUS" -gt 1 ] && echo "-j$RPM_BUILD_NCPUS")

--- a/macros
+++ b/macros
@@ -124,6 +124,7 @@
     /usr/lib/rpm/brp-python-hardlink \
     %{!?disable_docs_package:/usr/lib/rpm/meego/find-docs.sh %{buildroot}} \
     %{!?__jar_repack:/usr/lib/rpm/meego/brp-java-repack-jars} \
+    %{?__brp_remove_la_files} \
 %{nil}
 
 #    /usr/lib/rpm/meego/brp-implant-ident-static


### PR DESCRIPTION
- Remove our copy of `%make_install`
  - The clean up la-files is replaced with brp-remove-files from rpm-4.17      (https://github.com/sailfishos/rpm/pull/14)
  - Deletion or keeping of static libraries should be explicit. If a package fails
    it's on purpose
  - Add `brp-remove-la-files` to post-install to remove la files
- packages we use make should use `%qmake5_install` instead of `%make_install`
- Remove configuration to use XZ compression => we switched to ZSTD in JB#56416