### PR TITLE
Improve brp-compress performance. JB#63057

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 
 install:
 	mkdir -p $(DESTDIR)/usr/lib/rpm/meego
-	cp -pr * $(DESTDIR)/usr/lib/rpm/meego/
+	cp -pr $(shell ls | grep -v "installroot") $(DESTDIR)/usr/lib/rpm/meego/
 	rm -f $(DESTDIR)/usr/lib/rpm/meego/Makefile
 	rm -f $(DESTDIR)/usr/lib/rpm/meego/meego-rpm-config.spec
 

--- a/brp-compress
+++ b/brp-compress
@@ -27,28 +27,28 @@ for f in `find $MANDIRS -type f`; do
 	fi
 
 	case "$f" in
-	 *.Z) gunzip -f $f; b=`echo $f | sed -e 's/\.Z$//'`;;
-	 *.gz) gunzip -f $f; b=`echo $f | sed -e 's/\.gz$//'`;;
-	 *.bz2) bunzip2 -f $f; b=`echo $f | sed -e 's/\.bz2$//'`;;
-	 *) b=$f;;
+		*.Z) gunzip -f $f; b=`echo $f | sed -e 's/\.Z$//'`;;
+		*.gz) gunzip -f $f; b=`echo $f | sed -e 's/\.gz$//'`;;
+		*.bz2) bunzip2 -f $f; b=`echo $f | sed -e 's/\.bz2$//'`;;
+		*) b=$f;;
 	esac
 
 	$COMPRESS $b </dev/null 2>/dev/null || {
-	    inode=`ls -i $b | awk '{ print $1 }'`
-	    others=`find $MANDIRS -type f -inum $inode`
-	    if [ -n "$others" ]; then
-		for afile in $others ; do
-		    [ "$afile" != "$b" ] && rm -f $afile
-		done
-		$COMPRESS -f $b
-		for afile in $others ; do
-		    [ "$afile" != "$b" ] && ln $b$COMPRESS_EXT $afile$COMPRESS_EXT
-		done
-	    else
-		$COMPRESS -f $b
-	    fi
+		inode=`ls -i $b | awk '{ print $1 }'`
+		others=`find $MANDIRS -type f -inum $inode`
+		if [ -n "$others" ]; then
+			for afile in $others ; do
+				[ "$afile" != "$b" ] && rm -f $afile
+			done
+			$COMPRESS -f $b
+			for afile in $others ; do
+				[ "$afile" != "$b" ] && ln $b$COMPRESS_EXT $afile$COMPRESS_EXT
+			done
+		else
+			$COMPRESS -f $b
+		fi
 	}
-    done
+done
 
 for f in `find $MANDIRS -type l`; do
 	l=`ls -l $f | sed -e 's/.* -> //' -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//'`

--- a/brp-compress
+++ b/brp-compress
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 # If using normal root, avoid changing anything.
-if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+if [ -z "$RPM_BUILD_ROOT" ] || [ "$RPM_BUILD_ROOT" = "/" ]; then
 	exit 0
 fi
 
-cd $RPM_BUILD_ROOT
+cd "$RPM_BUILD_ROOT" || exit 1
 
 # Compress man pages
 COMPRESS="gzip -9 -n"
@@ -21,38 +21,38 @@ if [ -z "$MANDIRS" ]; then
 	exit 0
 fi
 
-for f in `find $MANDIRS -type f`; do
-	if [ ! -f "$f" ] || [ "`basename $f`" = "dir" ]; then
+for f in $(find "$MANDIRS" -type f); do
+	if [ ! -f "$f" ] || [ "$(basename "$f")" = "dir" ]; then
 		continue
 	fi
 
 	case "$f" in
-		*.Z) gunzip -f $f; b=`echo $f | sed -e 's/\.Z$//'`;;
-		*.gz) gunzip -f $f; b=`echo $f | sed -e 's/\.gz$//'`;;
-		*.bz2) bunzip2 -f $f; b=`echo $f | sed -e 's/\.bz2$//'`;;
+		*.Z) gunzip -f "$f"; b=$(echo "$f" | sed -e 's/\.Z$//');;
+		*.gz) gunzip -f "$f"; b=$(echo "$f" | sed -e 's/\.gz$//');;
+		*.bz2) bunzip2 -f "$f"; b=$(echo "$f" | sed -e 's/\.bz2$//');;
 		*) b=$f;;
 	esac
 
-	$COMPRESS $b </dev/null 2>/dev/null || {
-		inode=`ls -i $b | awk '{ print $1 }'`
-		others=`find $MANDIRS -type f -inum $inode`
+	$COMPRESS "$b" </dev/null 2>/dev/null || {
+		inode=$(ls -i "$b" | awk '{ print $1 }')
+		others=$(find "$MANDIRS" -type f -inum "$inode")
 		if [ -n "$others" ]; then
 			for afile in $others ; do
-				[ "$afile" != "$b" ] && rm -f $afile
+				[ "$afile" != "$b" ] && rm -f "$afile"
 			done
-			$COMPRESS -f $b
+			$COMPRESS -f "$b"
 			for afile in $others ; do
-				[ "$afile" != "$b" ] && ln $b$COMPRESS_EXT $afile$COMPRESS_EXT
+				[ "$afile" != "$b" ] && ln "$b$COMPRESS_EXT" "$afile$COMPRESS_EXT"
 			done
 		else
-			$COMPRESS -f $b
+			$COMPRESS -f "$b"
 		fi
 	}
 done
 
-for f in `find $MANDIRS -type l`; do
-	l=`ls -l $f | sed -e 's/.* -> //' -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//'`
-	rm -f $f
-	b=`echo $f | sed -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//'`
-	ln -sf $l$COMPRESS_EXT $b$COMPRESS_EXT
+for f in $(find "$MANDIRS" -type l); do
+	l=$(ls -l "$f" | sed -e 's/.* -> //' -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//')
+	rm -f "$f"
+	b=$(echo "$f" | sed -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//')
+	ln -sf "$l$COMPRESS_EXT" "$b$COMPRESS_EXT"
 done

--- a/brp-compress
+++ b/brp-compress
@@ -11,14 +11,17 @@ cd $RPM_BUILD_ROOT
 COMPRESS="gzip -9 -n"
 COMPRESS_EXT=.gz
 
-for d in ./usr/man/man* ./usr/man/*/man* ./usr/info \
+MANDIRS=$(ls -d ./usr/man/man* ./usr/man/*/man* ./usr/info \
 	./usr/share/man/man* ./usr/share/man/*/man* ./usr/share/info \
 	./usr/kerberos/man ./usr/X11R6/man/man* ./usr/lib/perl5/man/man* \
-	./usr/share/doc/*/man/man* ./usr/lib/*/man/man*
-do
-    [ -d $d ] || continue
-    for f in `find $d -type f`
-    do
+	./usr/share/doc/*/man/man* ./usr/lib/*/man/man* 2>/dev/null)
+
+# No folders found, nothing to do
+if [ -z "$MANDIRS" ]; then
+	exit 0
+fi
+
+for f in `find $MANDIRS -type f`; do
         [ -f "$f" ] || continue
 	[ "`basename $f`" = "dir" ] && continue
 
@@ -31,7 +34,7 @@ do
 
 	$COMPRESS $b </dev/null 2>/dev/null || {
 	    inode=`ls -i $b | awk '{ print $1 }'`
-	    others=`find $d -type f -inum $inode`
+	    others=`find $MANDIRS -type f -inum $inode`
 	    if [ -n "$others" ]; then
 		for afile in $others ; do
 		    [ "$afile" != "$b" ] && rm -f $afile
@@ -46,11 +49,9 @@ do
 	}
     done
 
-    for f in `find $d -type l`
-    do
+for f in `find $MANDIRS -type l`; do
 	l=`ls -l $f | sed -e 's/.* -> //' -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//'`
 	rm -f $f
 	b=`echo $f | sed -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//'`
 	ln -sf $l$COMPRESS_EXT $b$COMPRESS_EXT
-    done
 done

--- a/brp-compress
+++ b/brp-compress
@@ -22,8 +22,9 @@ if [ -z "$MANDIRS" ]; then
 fi
 
 for f in `find $MANDIRS -type f`; do
-        [ -f "$f" ] || continue
-	[ "`basename $f`" = "dir" ] && continue
+	if [ ! -f "$f" ] || [ "`basename $f`" = "dir" ]; then
+		continue
+	fi
 
 	case "$f" in
 	 *.Z) gunzip -f $f; b=`echo $f | sed -e 's/\.Z$//'`;;

--- a/brp-compress
+++ b/brp-compress
@@ -21,7 +21,7 @@ if [ -z "$MANDIRS" ]; then
 	exit 0
 fi
 
-for f in $(find "$MANDIRS" -type f); do
+find "$MANDIRS" -type f | while read -r f; do
 	if [ ! -f "$f" ] || [ "$(basename "$f")" = "dir" ]; then
 		continue
 	fi
@@ -50,7 +50,7 @@ for f in $(find "$MANDIRS" -type f); do
 	}
 done
 
-for f in $(find "$MANDIRS" -type l); do
+find "$MANDIRS" -type l | while read -r f; do
 	l=$(ls -l "$f" | sed -e 's/.* -> //' -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//')
 	rm -f "$f"
 	b=$(echo "$f" | sed -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//')

--- a/brp-compress
+++ b/brp-compress
@@ -34,7 +34,7 @@ find "$MANDIRS" -type f | while read -r f; do
 	esac
 
 	$COMPRESS "$b" </dev/null 2>/dev/null || {
-		inode=$(ls -i "$b" | awk '{ print $1 }')
+		inode=$(stat -c "%i" "$b")
 		others=$(find "$MANDIRS" -type f -inum "$inode")
 		if [ -n "$others" ]; then
 			for afile in $others ; do
@@ -51,7 +51,7 @@ find "$MANDIRS" -type f | while read -r f; do
 done
 
 find "$MANDIRS" -type l | while read -r f; do
-	l=$(ls -l "$f" | sed -e 's/.* -> //' -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//')
+	l=$(basename "$(readlink -f "$f")" | sed -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//')
 	rm -f "$f"
 	b=$(echo "$f" | sed -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//')
 	ln -sf "$l$COMPRESS_EXT" "$b$COMPRESS_EXT"

--- a/find-requires
+++ b/find-requires
@@ -21,10 +21,10 @@ fi
 # --- Grab the file manifest and classify files.
 #filelist=`sed "s/['\"]/\\\&/g"`
 filelist=`sed "s/[]['\"*?{}]/\\\\\&/g"`
-exelist=`echo $filelist | xargs -r file | egrep -v ":.* (commands|script) " | \
+exelist=`echo $filelist | xargs -r file | grep -v -E ":.* (commands|script) " | \
 	grep ":.*executable" | cut -d: -f1`
 scriptlist=`echo $filelist | xargs -r file | \
-	egrep ":.* (commands|script) " | cut -d: -f1`
+	grep -E ":.* (commands|script) " | cut -d: -f1`
 liblist=`echo $filelist | xargs -r file | \
 	grep ":.*shared object" | cut -d : -f1`
 

--- a/rpm/meego-rpm-config.spec
+++ b/rpm/meego-rpm-config.spec
@@ -5,10 +5,9 @@ Name:       meego-rpm-config
 Summary:    Mer specific rpm configuration files (from MeeGo)
 Version:    0.18-2
 Release:    1
-Group:      Development/System
 License:    GPLv2+ and GPLv3+
 BuildArch:  noarch
-URL:        http://git.merproject.org/mer-core/meego-rpm-config
+URL:        https://github.com/sailfishos/meego-rpm-config
 Source0:    meego-rpm-config-%{version}.tar.bz2
 
 %description
@@ -21,9 +20,7 @@ Inherited from MeeGo
 %build
 
 %install
-rm -rf %{buildroot}
-make DESTDIR=${RPM_BUILD_ROOT} install
+%make_install
 
 %files
-%defattr(-,root,root,-)
 %{_prefix}/lib/rpm/meego


### PR DESCRIPTION
`brp-compress` executed `find` twice for every folder in the man structure, which meant for `filesystem` package it was executed 30100 times (!!) without a single manpage to be found. I reworked the script so that it calls `find` two times, but with a long list of folders as parameters instead. This took the overall build time of `filesystem` on my laptop from ~185 seconds to ~60 seconds, dropping `brp-compress` execution time from two minutes to roughly a second.

I tested the docs build result with `rpm-doc` package, which resulted in same size and same contents with the old and new script.

While at it, I fixed the messy  whitespace usage in `brp-compress`, cleaned up the code a little, removed uses of `egrep` and fixed the project to compile with Platform SDK too.