### PR TITLE
Exit early if there are no files to process. JB#63057

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 
 install:
 	mkdir -p $(DESTDIR)/usr/lib/rpm/meego
-	cp -pr * $(DESTDIR)/usr/lib/rpm/meego/
+	cp -pr $(shell ls | grep -v "installroot") $(DESTDIR)/usr/lib/rpm/meego/
 	rm -f $(DESTDIR)/usr/lib/rpm/meego/Makefile
 	rm -f $(DESTDIR)/usr/lib/rpm/meego/meego-rpm-config.spec
 

--- a/brp-compress
+++ b/brp-compress
@@ -11,10 +11,16 @@ cd $RPM_BUILD_ROOT
 COMPRESS="gzip -9 -n"
 COMPRESS_EXT=.gz
 
-for d in ./usr/man/man* ./usr/man/*/man* ./usr/info \
-	./usr/share/man/man* ./usr/share/man/*/man* ./usr/share/info \
-	./usr/kerberos/man ./usr/X11R6/man/man* ./usr/lib/perl5/man/man* \
-	./usr/share/doc/*/man/man* ./usr/lib/*/man/man*
+MANDIRS=$(echo ./usr/man/man* ./usr/man/*/man* ./usr/info \
+        ./usr/share/man/man* ./usr/share/man/*/man* ./usr/share/info \
+        ./usr/kerberos/man ./usr/X11R6/man/man* ./usr/lib/perl5/man/man* \
+        ./usr/share/doc/*/man/man* ./usr/lib/*/man/man*)
+
+# If there are no files, there's nothing to do.
+FILE=$(find $MANDIRS -type f -print -quit 2>/dev/null)
+[ -z "$FILE" ] && exit 0
+
+for d in $MANDIRS
 do
     [ -d $d ] || continue
     for f in `find $d -type f`

--- a/find-requires
+++ b/find-requires
@@ -21,10 +21,10 @@ fi
 # --- Grab the file manifest and classify files.
 #filelist=`sed "s/['\"]/\\\&/g"`
 filelist=`sed "s/[]['\"*?{}]/\\\\\&/g"`
-exelist=`echo $filelist | xargs -r file | egrep -v ":.* (commands|script) " | \
+exelist=`echo $filelist | xargs -r file | grep -v -E ":.* (commands|script) " | \
 	grep ":.*executable" | cut -d: -f1`
 scriptlist=`echo $filelist | xargs -r file | \
-	egrep ":.* (commands|script) " | cut -d: -f1`
+	grep -E ":.* (commands|script) " | cut -d: -f1`
 liblist=`echo $filelist | xargs -r file | \
 	grep ":.*shared object" | cut -d : -f1`
 

--- a/rpm/meego-rpm-config.spec
+++ b/rpm/meego-rpm-config.spec
@@ -5,10 +5,9 @@ Name:       meego-rpm-config
 Summary:    Mer specific rpm configuration files (from MeeGo)
 Version:    0.18-2
 Release:    1
-Group:      Development/System
 License:    GPLv2+ and GPLv3+
 BuildArch:  noarch
-URL:        http://git.merproject.org/mer-core/meego-rpm-config
+URL:        https://github.com/sailfishos/meego-rpm-config
 Source0:    meego-rpm-config-%{version}.tar.bz2
 
 %description
@@ -21,9 +20,7 @@ Inherited from MeeGo
 %build
 
 %install
-rm -rf %{buildroot}
-make DESTDIR=${RPM_BUILD_ROOT} install
+%make_install
 
 %files
-%defattr(-,root,root,-)
 %{_prefix}/lib/rpm/meego


### PR DESCRIPTION
First, check if there are any files at all for processing. If there are not, just exit from the script. This prevents spinning around in empty folders doing nothing, which in the case of `filesystem` package resulted in a mind-boggling amount of wasted effort.

This is a simplified rework of #8 instead of what approached a complete rewrite. Better keep it simple and not deviate too far from upstream.

- Exit early if there are no files to process
- Clean up spec file
- Fix compiling in Platform SDK
- Don't use obsolete egrep