### PR TITLE
Remove custom clean macro. JB#62519 JB#55344 

### DIFF
--- a/macros
+++ b/macros
@@ -190,10 +190,6 @@ unset DISPLAY\
 unset DISPLAY\
 %{nil}
 
-%clean %%clean\
-rm -rf %{?buildroot:%{buildroot}} \
-%{nil}
-
 %find_lang      /usr/lib/rpm/find-lang.sh %{buildroot}
 %find_docs      /usr/lib/rpm/find-docs.sh %{buildroot}
 

--- a/rpm/meego-rpm-config.spec
+++ b/rpm/meego-rpm-config.spec
@@ -3,7 +3,7 @@ Name:       meego-rpm-config
 %define disable_docs_package 1
 
 Summary:    Mer specific rpm configuration files (from MeeGo)
-Version:    0.19
+Version:    0.20
 Release:    1
 License:    GPLv2+ and GPLv3+
 BuildArch:  noarch


### PR DESCRIPTION
This prevents packages using custom clean macro to e.g. add write permissions to files before removing them. This is the default action in RPM anyway, so there shouldn't be any need for this.